### PR TITLE
[sl-core] Fix source pointer in l2mt bootstrap.

### DIFF
--- a/slc/ChangeLog
+++ b/slc/ChangeLog
@@ -1,3 +1,10 @@
+2016-07-14  Alyssa Milburn  <amilburn@zall.org>
+
+	Copy LEON2-MT data segment starting from the (aligned) end of the
+	text data, not the end of the text segment.
+
+	* tools/lib/mt/l2mt/bootstrap.c: Use correct value for src.
+
 2016-07-14  Alyssa Milburn <amilburn@zall.org>
 
 	Remove pure attribute from non-pure divide functions.

--- a/slc/tools/lib/mt/l2mt/bootstrap.c
+++ b/slc/tools/lib/mt/l2mt/bootstrap.c
@@ -1,9 +1,9 @@
 extern unsigned _edata;
 extern unsigned _data_start;
-extern unsigned _etext;
+extern unsigned _endtext;
 
 void __copyram(void) {
-    unsigned *src = &_etext;
+    unsigned *src = &_endtext;
     unsigned *dst = &_data_start;
     while (dst != &_edata)
 	*dst++ = *src++;


### PR DESCRIPTION
Copy LEON2-MT data segment starting from the (aligned) end of the
text data, not the end of the text segment.
