### PR TITLE
[sl-core] Only clear annulled delay slots for unconditional branches.

### DIFF
--- a/slc/ChangeLog
+++ b/slc/ChangeLog
@@ -1,3 +1,11 @@
+2016-11-10  Alyssa Milburn  <amilburn@zall.org>
+
+	Only clear (SPARC) annulled delay slots for unconditional
+	branches, where the delay slot instruction will never be
+	executed.
+
+	* tools/slc/mt/mtsparc/asmproc/base.py: Only match b[n|a],a.
+
 2016-11-07  Alyssa Milburn  <amilburn@zall.org>
 
 	Suppress/redirect warnings when running LEON2-MT simulator.

--- a/slc/tools/slc/mt/mtsparc/asmproc/base.py
+++ b/slc/tools/slc/mt/mtsparc/asmproc/base.py
@@ -534,7 +534,7 @@ def protectend(fundata, items):
         yield (type, content, comment)
         
 
-_re_annul = re.compile(r'\S+,a(\s+.*|\s*)$')
+_re_annul = re.compile(r'b[na]?,a(\s+.*|\s*)$')
 def fillannulnop(fundata,items):
     """
     Fill a "nop" in the delay slot of branch-and-annul


### PR DESCRIPTION
Only clear (SPARC) annulled delay slots for unconditional branches,
where the delay slot instruction will never be executed.

* tools/slc/mt/mtsparc/asmproc/base.py: Only match b[n|a],a.