### PR TITLE
[sl-core] Fix extra IPC statistic when using integer math.

### DIFF
--- a/slc/ChangeLog
+++ b/slc/ChangeLog
@@ -1,5 +1,11 @@
 2016-11-24  Alyssa Milburn  <amilburn@zall.org>
 
+	Fix extra IPC statistic when using integer math.
+
+	* lib/slsys/perf/perf.c: Multiply before dividing.
+
+2016-11-24  Alyssa Milburn  <amilburn@zall.org>
+
 	Fix printing large unsigned integers.
 
 	* lib/libc/bsd/libc/stdio/printfcommon.h: Initialize svar.

--- a/slc/lib/slsys/perf/perf.c
+++ b/slc/lib/slsys/perf/perf.c
@@ -146,7 +146,7 @@ ARITH mtperf_compute_extra(const counter_t* before, const counter_t* after, unsi
     {
         ARITH itotal = after[MTPERF_EXECUTED_INSNS] - before[MTPERF_EXECUTED_INSNS];
         itotal = DIV(itotal, ncores);
-        if (elapsed) return itotal * DIV(core_rate, elapsed);
+        if (elapsed) return DIV(itotal * core_rate, elapsed);
         break;
     }
 #if defined(__slc_os_sim__)


### PR DESCRIPTION
* lib/slsys/perf/perf.c: Multiply before dividing.