### PR TITLE
[sl-core] Sync perf column names for LEON2(-MT).

### DIFF
--- a/slc/ChangeLog
+++ b/slc/ChangeLog
@@ -1,5 +1,12 @@
 2016-11-24  Alyssa Milburn  <amilburn@zall.org>
 
+	Sync perf column names for LEON2(-MT).
+
+	* lib/slsys/perf/perf.c: Add "pl_eff_x100" to mtperf_column_names
+	for LEON2/LEON2-MT.
+
+2016-11-24  Alyssa Milburn  <amilburn@zall.org>
+
 	Flush stdout/stderr when outputting from FPGA buffer.
 
 	* tools/leon2mt-fpga-ctl.in: Flush after writing.

--- a/slc/lib/slsys/perf/perf.c
+++ b/slc/lib/slsys/perf/perf.c
@@ -62,6 +62,8 @@ const char* mtperf_counter_names[] = {
     "sw_active_aq",
     "sw_waiting_wq",
     "sw_tt_reg_pending",
+// computed columns
+    "pl_eff_x100",
 #elif defined(__slc_os_fpga__) && defined(__slc_arch_mtsparc__)
     "ic_holdn",
     "dc_holdn",


### PR DESCRIPTION
Not sure whether this is the best fix - the #ifdefs are getting a bit complex here, this is just the minimal-change fix to make the perf code work again.